### PR TITLE
feat(workflow): Adds native executable packages to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
           git ls-remote --tags origin "refs/tags/${tag_name}"
 
   build-release-assets:
-    name: Build ${{ matrix.asset_name }}
+    name: Build jar bundle ${{ matrix.asset_name }}
     needs: prepare-release
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -197,11 +197,123 @@ jobs:
           path: ${{ matrix.asset_name }}-${{ needs.prepare-release.outputs.version }}.zip
           if-no-files-found: error
 
+  build-native-packages:
+    name: Build native launcher ${{ matrix.asset_name }}
+    needs: prepare-release
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - asset_name: Turris-windows-x64-exe
+            os: windows-latest
+            maven_profile: windows-x64
+            jar_classifier: natives-windows
+            archive_ext: zip
+
+          - asset_name: Turris-macos-arm64-dmg
+            os: macos-14
+            maven_profile: macos-arm64
+            jar_classifier: natives-macos-arm64
+            archive_ext: dmg
+
+          - asset_name: Turris-macos-x64-dmg
+            os: macos-13
+            maven_profile: macos-x64
+            jar_classifier: natives-macos
+            archive_ext: dmg
+
+          - asset_name: Turris-linux-x64-executable
+            os: ubuntu-latest
+            maven_profile: linux-x64
+            jar_classifier: natives-linux
+            archive_ext: tar.gz
+
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.target_sha }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Set Maven project version
+        shell: bash
+        run: |
+          mvn -B versions:set \
+            -DnewVersion="${{ needs.prepare-release.outputs.version }}" \
+            -DgenerateBackupPoms=false
+
+      - name: Build platform jar
+        shell: bash
+        run: |
+          mvn -B -P "${{ matrix.maven_profile }}" package
+
+      - name: Prepare jpackage input
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.prepare-release.outputs.version }}"
+          jar_name="turris-${version}-${{ matrix.jar_classifier }}.jar"
+
+          test -f "target/${jar_name}"
+          test -d target/assets
+
+          mkdir -p jpackage-input
+          cp "target/${jar_name}" "jpackage-input/${jar_name}"
+          cp -R target/assets jpackage-input/assets
+
+      - name: Build Windows app image
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $version = "${{ needs.prepare-release.outputs.version }}"
+          $jar = "turris-$version-${{ matrix.jar_classifier }}.jar"
+          jpackage --type app-image --name Turris --app-version "$version" --input jpackage-input --main-jar "$jar" --dest native --vendor OleeL
+          Compress-Archive -Path native/Turris/* -DestinationPath "${{ matrix.asset_name }}-$version.zip" -Force
+
+      - name: Build macOS DMG
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.prepare-release.outputs.version }}"
+          jar="turris-${version}-${{ matrix.jar_classifier }}.jar"
+          jpackage --type dmg --name Turris --app-version "${version}" --input jpackage-input --main-jar "${jar}" --dest native --vendor OleeL
+          dmg="$(find native -maxdepth 1 -name '*.dmg' | head -n 1)"
+          test -f "${dmg}"
+          cp "${dmg}" "${{ matrix.asset_name }}-${version}.dmg"
+
+      - name: Build Linux app image
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.prepare-release.outputs.version }}"
+          jar="turris-${version}-${{ matrix.jar_classifier }}.jar"
+          jpackage --type app-image --name Turris --app-version "${version}" --input jpackage-input --main-jar "${jar}" --dest native --vendor OleeL
+          tar -czf "${{ matrix.asset_name }}-${version}.tar.gz" -C native Turris
+
+      - name: Upload native package artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: ${{ matrix.asset_name }}
+          path: ${{ matrix.asset_name }}-${{ needs.prepare-release.outputs.version }}.${{ matrix.archive_ext }}
+          if-no-files-found: error
+
   publish-release:
     name: Publish GitHub release
     needs:
       - prepare-release
       - build-release-assets
+      - build-native-packages
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -215,9 +327,9 @@ jobs:
       - name: Show release assets
         shell: bash
         run: |
-          find release-assets -type f -maxdepth 1 -print -exec ls -lh {} \;
-          asset_count="$(find release-assets -maxdepth 1 -name '*.zip' | wc -l)"
-          test "${asset_count}" -eq 7
+          find release-assets -maxdepth 1 -type f -print -exec ls -lh {} \;
+          asset_count="$(find release-assets -maxdepth 1 -type f | wc -l)"
+          test "${asset_count}" -ge 11
 
       - name: Publish release
         uses: softprops/action-gh-release@v2
@@ -227,7 +339,7 @@ jobs:
           target_commitish: ${{ needs.prepare-release.outputs.target_sha }}
           make_latest: true
           generate_release_notes: true
-          files: release-assets/*.zip
+          files: release-assets/*
           fail_on_unmatched_files: true
 
       - name: Verify GitHub release assets
@@ -239,4 +351,4 @@ jobs:
           tag_name="${{ needs.prepare-release.outputs.tag_name }}"
           gh release view "${tag_name}" --json tagName,name,assets --jq '.tagName + " " + .name, (.assets[] | .name)'
           asset_count="$(gh release view "${tag_name}" --json assets --jq '.assets | length')"
-          test "${asset_count}" -ge 7
+          test "${asset_count}" -ge 11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,6 +349,6 @@ jobs:
         run: |
           set -euo pipefail
           tag_name="${{ needs.prepare-release.outputs.tag_name }}"
-          gh release view "${tag_name}" --json tagName,name,assets --jq '.tagName + " " + .name, (.assets[] | .name)'
-          asset_count="$(gh release view "${tag_name}" --json assets --jq '.assets | length')"
+          gh release view "${tag_name}" --repo "${GITHUB_REPOSITORY}" --json tagName,name,assets --jq '.tagName + " " + .name, (.assets[] | .name)'
+          asset_count="$(gh release view "${tag_name}" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets | length')"
           test "${asset_count}" -ge 11

--- a/README.md
+++ b/README.md
@@ -34,36 +34,38 @@ The executable jar is written to `target/` and includes the selected LWJGL nativ
 
 ## Run locally
 
-The game currently loads assets from a filesystem path named `assets/...`, so the easiest local run is from the project root with an `assets` symlink pointing at the packaged assets:
+The game currently loads assets from a filesystem path named `assets/...`, so run the jar from inside `target/`, where Maven copies the packaged `assets/` directory:
 
 ```sh
 mvn package
-ln -s target/assets assets 2>/dev/null || true
-java -jar target/turris-1.0.0-natives-macos-arm64.jar
+cd target
+java -jar turris-1.0.0-natives-macos-arm64.jar
 ```
 
-Use the jar that matches your platform:
+Use the jar that matches your platform from inside `target/`:
 
 ```text
-target/turris-1.0.0-natives-windows.jar       Windows x64
-target/turris-1.0.0-natives-windows-x86.jar   Windows x86
-target/turris-1.0.0-natives-macos.jar         macOS Intel
-target/turris-1.0.0-natives-macos-arm64.jar   macOS Apple Silicon
-target/turris-1.0.0-natives-linux.jar         Linux x64
-target/turris-1.0.0-natives-linux-arm32.jar   Linux ARM32
-target/turris-1.0.0-natives-linux-arm64.jar   Linux ARM64
+turris-1.0.0-natives-windows.jar       Windows x64
+turris-1.0.0-natives-windows-x86.jar   Windows x86
+turris-1.0.0-natives-macos.jar         macOS Intel
+turris-1.0.0-natives-macos-arm64.jar   macOS Apple Silicon
+turris-1.0.0-natives-linux.jar         Linux x64
+turris-1.0.0-natives-linux-arm32.jar   Linux ARM32
+turris-1.0.0-natives-linux-arm64.jar   Linux ARM64
 ```
 
 On Apple Silicon Macs, use:
 
 ```sh
-java -jar target/turris-1.0.0-natives-macos-arm64.jar
+cd target
+java -jar turris-1.0.0-natives-macos-arm64.jar
 ```
 
 On Intel Macs, use:
 
 ```sh
-java -jar target/turris-1.0.0-natives-macos.jar
+cd target
+java -jar turris-1.0.0-natives-macos.jar
 ```
 
 ## Build all release jars
@@ -96,12 +98,31 @@ This repository has a GitHub Actions release workflow in `.github/workflows/rele
 On every push to `main`, the workflow:
 
 1. calculates a version with GitVersion using `GitVersion.yml`
-2. sets the Maven project version for the CI build
+2. creates a release git tag
 3. builds all supported platform jars
 4. packages each jar with the `assets/` directory
-5. publishes the zip files to a GitHub Release
+5. builds native launchers/installers where GitHub-hosted runners support them
+6. publishes all artifacts to a GitHub Release
 
 The workflow can also be started manually from the GitHub Actions tab with `workflow_dispatch`.
+
+Release assets include jar bundles for all supported LWJGL native classifiers, plus native launcher packages for common desktop targets:
+
+```text
+Turris-windows-x64-<version>.zip              Jar bundle
+Turris-windows-x86-<version>.zip              Jar bundle
+Turris-macos-arm64-<version>.zip              Jar bundle
+Turris-macos-x64-<version>.zip                Jar bundle
+Turris-linux-x64-<version>.zip                Jar bundle
+Turris-linux-arm32-<version>.zip              Jar bundle
+Turris-linux-arm64-<version>.zip              Jar bundle
+Turris-windows-x64-exe-<version>.zip          Windows app image containing Turris.exe
+Turris-macos-arm64-dmg-<version>.dmg          macOS Apple Silicon DMG
+Turris-macos-x64-dmg-<version>.dmg            macOS Intel DMG
+Turris-linux-x64-executable-<version>.tar.gz  Linux app image containing executable launcher
+```
+
+GitHub-hosted runners do not provide a 32-bit Windows or 32-bit Linux environment for `jpackage`, so the native launcher artifacts are currently x64/Apple-Silicon only. Windows x86 is still published as a jar bundle.
 
 ## Packaging a release manually
 

--- a/src/main/java/com/team62/turris/Main.java
+++ b/src/main/java/com/team62/turris/Main.java
@@ -5,6 +5,7 @@ import com.team62.turris.engine.io.Window;
 import com.team62.turris.playing.Playing;
 import com.team62.turris.settings.io.Load;
 import java.io.File;
+import java.net.URISyntaxException;
 import org.lwjgl.system.Platform;
 
 /**
@@ -31,6 +32,7 @@ public class Main {
         boolean vsync = false; // Vsync settings
         String windowName = "Turris"; // Name of the window
 
+        configureWorkingDirectoryForAssets();
         final String userDir = System.getProperty("user.dir");
         System.out.println("Working Directory = " + userDir);
 
@@ -90,6 +92,38 @@ public class Main {
         }
 
         Audio.destroy();
+    }
+
+    private static void configureWorkingDirectoryForAssets()
+        throws URISyntaxException {
+        if (new File("assets").isDirectory()) {
+            return;
+        }
+
+        File codePath = new File(
+            Main.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .toURI()
+        );
+        File codeDir = codePath.isDirectory()
+            ? codePath
+            : codePath.getParentFile();
+        File[] candidates = {
+            codeDir,
+            codeDir == null ? null : codeDir.getParentFile(),
+            new File("target"),
+        };
+
+        for (File candidate : candidates) {
+            if (
+                candidate != null && new File(candidate, "assets").isDirectory()
+            ) {
+                System.setProperty("user.dir", candidate.getAbsolutePath());
+                return;
+            }
+        }
     }
 
     public static void printMouseCoordsOnClick() {


### PR DESCRIPTION
Introduces a new GitHub Actions job to build platform-specific native launchers and installers using `jpackage`. This enables the creation of:
- Windows app images (as `.zip` archives containing an `.exe`)
- macOS disk images (`.dmg`)
- Linux app images (as `.tar.gz` archives containing an executable launcher)

The release workflow is updated to publish these new artifacts alongside the existing jar bundles, expanding the range of available downloads.

To support the new packaging, the application's asset loading mechanism is enhanced to intelligently locate the `assets/` directory, ensuring proper startup regardless of whether it's run from a jar bundle or a native package.

The `README.md` is updated to reflect the new release artifacts, their naming conventions, and adjusted instructions for running the game locally. This change streamlines distribution and provides a more convenient out-of-the-box experience for users on various desktop platforms.

Relates to feature/executable-releases